### PR TITLE
Fix the lists of matches in MatchList and players in MatchDetails

### DIFF
--- a/src/components/MatchDetails/MatchDetails.tsx
+++ b/src/components/MatchDetails/MatchDetails.tsx
@@ -1,7 +1,6 @@
 import { FC, useMemo } from "react";
 import useFetch from "use-http";
 import { PlayerStats, StatsResponse } from "../../types";
-import { toList } from "../../util/toList";
 import styles from "./MatchDetails.module.css";
 import { Team } from "./Team";
 
@@ -21,15 +20,15 @@ export const MatchDetails: FC<MatchDetailsProps> = ({ matchId }) => {
       return [[], []];
     }
 
-    const [axisPlayers, alliesPlayers] = data.statsall;
+    const { axisPlayers, alliesPlayers }  = splitPlayersIntoTeams( data.statsall );
 
     const byEffiency = (a: PlayerStats, b: PlayerStats) => {
       return b.categories.efficiency - a.categories.efficiency;
     };
 
     return [
-      toList(axisPlayers).sort(byEffiency),
-      toList(alliesPlayers).sort(byEffiency),
+      axisPlayers.sort(byEffiency),
+      alliesPlayers.sort(byEffiency),
     ];
   }, [data]);
 
@@ -51,3 +50,20 @@ export const MatchDetails: FC<MatchDetailsProps> = ({ matchId }) => {
     </div>
   );
 };
+
+const splitPlayersIntoTeams = ( players: any[] ) => {
+  let axisPlayers: PlayerStats[] = [], alliesPlayers: PlayerStats[] = [];
+
+  players.forEach( player => {
+    Object.keys( player ).forEach( player_id => {
+      player = player[player_id]
+    } );
+    if ( player.team.toUpperCase() === "AXIS" ) {
+      axisPlayers.push( player );
+    } else {
+      alliesPlayers.push( player );
+    }
+  } );
+
+  return { alliesPlayers, axisPlayers };
+}

--- a/src/components/MatchList/MatchList.tsx
+++ b/src/components/MatchList/MatchList.tsx
@@ -13,12 +13,23 @@ export const MatchList: FC<MatchListProps> = ({ loading, matches }) => {
     return <div>Loading matches</div>;
   }
 
+  const games = matches.reduce( ( acc: Array<Match>, currentMatch: Match, index: number, array: Match[] ) => {
+    if ( index > 0 ) {
+      if ( currentMatch.match_id !== array[index - 1].match_id ) {
+        acc.push( currentMatch );
+      }
+    } else {
+      acc.push( currentMatch );
+    }
+    return acc;
+  }, [] );
+
   return (
     <div className={styles.body}>
-      {matches.map((match) => (
+      {games.map((match) => (
         <Link
           to={`/matches/${match.match_id}`}
-          key={match.match_round_id}
+          key={match.match_id}
           className={styles.row}
         >
           <div className={styles.matchId}>{match.match_id}</div>


### PR DESCRIPTION
in `MatchList`:
- reduced the array returned from `/matches/` to the actual list of matches. `/matches` returns the list of rounds even tho there is no way to have stats per round atm.

in `MatchDetails`:
- fix the list of players. API design of `Player` is not optimal (there shouldn't be a dynamic field in the object as it happens for the player ID).